### PR TITLE
Added forwardRef for Select component + aligned styling with Input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-1",
+	"version": "0.3.3-2",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-2",
+	"version": "0.3.3-3",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-4",
+	"version": "0.3.3-5",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.2",
+	"version": "0.3.3-0",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-5",
+	"version": "0.3.3",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-0",
+	"version": "0.3.3-1",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.3.3-3",
+	"version": "0.3.3-4",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -8,11 +8,7 @@ export interface InputProps {
 
 const Input = forwardRef<
 	HTMLInputElement,
-	InputProps &
-		React.DetailedHTMLProps<
-			React.InputHTMLAttributes<HTMLInputElement>,
-			HTMLInputElement
-		>
+	InputProps & React.InputHTMLAttributes<HTMLInputElement>
 >((props, ref) => {
 	const { label, errorMessage, ...inputProps } = props;
 	const id = useId('input');

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -13,8 +13,8 @@ const Input = forwardRef<
 
 	return (
 		<div className="space-y-2">
-			<label className="block text-gray-700 dark:text-gray-300 font-medium text-sm">
-				<span>{label}</span>
+			<label className="space-y-2">
+				<span className="input-label">{label}</span>
 				<input
 					ref={ref}
 					type="text"

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from 'react';
-import useId from './utils/useId';
 
 export interface InputProps {
 	label?: string;
@@ -11,23 +10,18 @@ const Input = forwardRef<
 	InputProps & React.InputHTMLAttributes<HTMLInputElement>
 >((props, ref) => {
 	const { label, errorMessage, ...inputProps } = props;
-	const id = useId('input');
 
 	return (
 		<div className="space-y-2">
-			<label
-				htmlFor={id}
-				className="block text-gray-700 dark:text-gray-300 font-medium text-sm"
-			>
-				{label}
+			<label className="block text-gray-700 dark:text-gray-300 font-medium text-sm">
+				<span>{label}</span>
+				<input
+					ref={ref}
+					type="text"
+					{...inputProps}
+					className={`py-2 px-4 rounded-md shadow focus:outline-none focus:ring focus:border-indigo-400 bg-white dark:bg-gray-900 dark:text-gray-100 ${props.className}`}
+				/>
 			</label>
-			<input
-				ref={ref}
-				id={id}
-				type="text"
-				{...inputProps}
-				className={`py-2 px-4 rounded-md shadow focus:outline-none focus:ring focus:border-indigo-400 bg-white dark:bg-gray-900 dark:text-gray-100 ${props.className}`}
-			/>
 			{errorMessage !== undefined && (
 				<div className="text-red-700 dark:text-red-600 text-sm">
 					{errorMessage}

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -19,10 +19,10 @@ const Select = forwardRef<
 
 	return (
 		<label className="flex flex-col space-y-2 text-black dark:text-gray-100">
-			<span>{label}</span>
+			<span className="input-label">{label}</span>
 			<select
 				ref={ref}
-				className="rounded px-4 py-2 bg-gray-100 dark:bg-gray-900 dark:text-white"
+				className="rounded-md px-4 py-2 bg-gray-100 dark:bg-gray-900 dark:text-white shadow focus:outline-none focus:ring focus:border-indigo-400"
 				onChange={changed}
 				{...selectProps}
 			>

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,20 +1,15 @@
-import React, { useCallback } from 'react';
-import { useId } from '.';
+import React, { forwardRef, useCallback } from 'react';
 
-export interface SelectProps
-	extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface SelectProps {
 	label: string;
 	children: any[];
 	onSelection?: (value: string) => void;
 }
 
-const Select = ({
-	label,
-	children,
-	onSelection,
-	...selectProps
-}: SelectProps) => {
-	const id = useId('select');
+const Select = forwardRef<
+	HTMLSelectElement,
+	SelectProps & React.SelectHTMLAttributes<HTMLSelectElement>
+>(({ label, children, onSelection, ...selectProps }, ref) => {
 	const changed = useCallback(
 		(e: React.ChangeEvent<HTMLSelectElement>) => {
 			onSelection?.(e.currentTarget.value);
@@ -23,40 +18,36 @@ const Select = ({
 	);
 
 	return (
-		<div className="flex flex-col space-y-2">
-			<label htmlFor={id} className="text-black dark:text-gray-100">
-				{label}
-			</label>
+		<label className="flex flex-col space-y-2 text-black dark:text-gray-100">
+			<span>{label}</span>
 			<select
-				id={id}
+				ref={ref}
 				className="rounded px-4 py-2 bg-gray-100 dark:bg-gray-900 dark:text-white"
 				onChange={changed}
 				{...selectProps}
 			>
 				{children}
 			</select>
-		</div>
+		</label>
 	);
-};
+});
 
-interface OptionProps {
+interface SelectOptionProps {
 	value: any;
 	children?: string;
 }
 
-const Option = ({ value, children }: OptionProps) => (
+export const SelectOption = ({ value, children }: SelectOptionProps) => (
 	<option value={value}>{children ?? value}</option>
 );
-Select.Option = Option;
 
-interface GroupProps {
+interface SelectGroupProps {
 	label: string;
 	children: any[];
 }
 
-const Group = ({ children, label }: GroupProps) => (
+export const SelectGroup = ({ children, label }: SelectGroupProps) => (
 	<optgroup label={label}>{children}</optgroup>
 );
-Select.Group = Group;
 
 export default Select;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -50,4 +50,4 @@ export const SelectGroup = ({ children, label }: SelectGroupProps) => (
 	<optgroup label={label}>{children}</optgroup>
 );
 
-export default Select;
+export default Select as any;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -18,7 +18,7 @@ const Select = forwardRef<
 	);
 
 	return (
-		<label className="flex flex-col space-y-2 text-black dark:text-gray-100">
+		<label className="flex flex-col space-y-2">
 			<span className="input-label">{label}</span>
 			<select
 				ref={ref}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,17 +3,16 @@ import ButtonContainer from './ButtonContainer';
 import DarkModeToggle from './DarkModeToggle';
 import Input from './Input';
 import Modal from './Modal';
-import Select from './Select';
 import Toggle from './Toggle';
 import useDarkMode from './utils/useDarkMode';
 import useDarkModeWithClass from './utils/useDarkModeWithClass';
 import useId from './utils/useId';
 
+export * from './Select';
 export {
 	Button,
 	ButtonContainer,
 	Input,
-	Select,
 	Modal,
 	DarkModeToggle,
 	Toggle,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import ButtonContainer from './ButtonContainer';
 import DarkModeToggle from './DarkModeToggle';
 import Input from './Input';
 import Modal from './Modal';
+import Select from './Select';
 import Toggle from './Toggle';
 import useDarkMode from './utils/useDarkMode';
 import useDarkModeWithClass from './utils/useDarkModeWithClass';
@@ -13,6 +14,7 @@ export {
 	Button,
 	ButtonContainer,
 	Input,
+	Select,
 	Modal,
 	DarkModeToggle,
 	Toggle,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -44,6 +44,10 @@
 	@apply underline text-blue-500 hover:text-blue-400 dark:text-blue-400 dark:hover:text-blue-500;
 }
 
+.input-label {
+	@apply block text-gray-700 dark:text-gray-300 font-medium text-sm;
+}
+
 .switch {
 	@apply relative inline-block w-16;
 	height: 34px;

--- a/stories/input/Select.stories.tsx
+++ b/stories/input/Select.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
 import React from 'react';
-import Select from '../../src/Select';
+import Select, { SelectGroup, SelectOption } from '../../src/Select';
 import { DarkModeToggle } from '../ThemeDisplay';
 
 export default {
@@ -14,8 +14,8 @@ export default {
 export const Simple = args => (
 	<DarkModeToggle darkMode={args.darkMode}>
 		<Select label="Test" onSelection={x => console.debug(`Selected: ${x}`)}>
-			<Select.Option value="A_value">A</Select.Option>
-			<Select.Option value="B_value">B</Select.Option>
+			<SelectOption value="A_value">A</SelectOption>
+			<SelectOption value="B_value">B</SelectOption>
 		</Select>
 	</DarkModeToggle>
 );
@@ -23,14 +23,14 @@ export const Simple = args => (
 export const Groups = args => (
 	<DarkModeToggle darkMode={args.darkMode}>
 		<Select label="Cars" onSelection={x => console.debug(x)}>
-			<Select.Group label="Swedish">
-				<Select.Option value="volvo">Volvo</Select.Option>
-				<Select.Option value="saab">Saab</Select.Option>
-			</Select.Group>
-			<Select.Group label="German">
-				<Select.Option value="mercedes">Mercedes</Select.Option>
-				<Select.Option value="audi">Audi</Select.Option>
-			</Select.Group>
+			<SelectGroup label="Swedish">
+				<SelectOption value="volvo">Volvo</SelectOption>
+				<SelectOption value="saab">Saab</SelectOption>
+			</SelectGroup>
+			<SelectGroup label="German">
+				<SelectOption value="mercedes">Mercedes</SelectOption>
+				<SelectOption value="audi">Audi</SelectOption>
+			</SelectGroup>
 		</Select>
 	</DarkModeToggle>
 );


### PR DESCRIPTION
Wrapped `Select` component in `forwardRef` to allow it to work with libraies such as `react-hook-form`.
Also aligned styling with `Input` component.

## Changes

- fix: Added forward ref for Select component
- wip: attempt to reexport
- wip: export Select again
- fix: moved input for Input into label
- style: aligned styling for Input and select
- style: removed unused styles
