### PR TITLE
Add useOnOutsideMouseDown hook 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"license": "MIT",
 	"name": "@oliverflecke/components-react",
 	"author": "Oliver Fleckenstein",

--- a/src/hooks/useOnOutsideMouseDown.ts
+++ b/src/hooks/useOnOutsideMouseDown.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export default function useOnOutsideMouseDown<T extends HTMLElement>(
+	ref: React.RefObject<T>,
+	action: () => void
+) {
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (ref.current && !ref.current.contains(event.target as HTMLElement)) {
+				action();
+			}
+		}
+
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => {
+			document.removeEventListener('mousedown', handleClickOutside);
+		};
+	}, [action, ref]);
+}


### PR DESCRIPTION
Adds a hook that registers mouse down events outside of a component. 
Can be usefull when needing to dismiss something like a modal.

# Commits
- feat: Added custom hook to run action when a click is registered outside of an node
- 0.5.0
